### PR TITLE
Suppress warnings on serialized fields

### DIFF
--- a/GizmoModule/GizmoModule.cs
+++ b/GizmoModule/GizmoModule.cs
@@ -10,6 +10,7 @@ namespace Unity.Labs.SuperScience
         public const float RayLength = 100f;
         const float k_RayWidth = 0.001f;
 
+#pragma warning disable 649
         [SerializeField]
         [Tooltip("Default sphere mesh used for drawing gizmo spheres.")]
         Mesh m_SphereMesh;
@@ -22,8 +23,15 @@ namespace Unity.Labs.SuperScience
         [Tooltip("Default quad mesh used for drawing gizmo wedges.")]
         Mesh m_QuadMesh;
 
+        [SerializeField]
+        Material m_GizmoMaterial;
+
+        [SerializeField]
+        Material m_GizmoCutoffMaterial;
+#pragma warning restore 649
+
         MaterialPropertyBlock m_GizmoProperties;
-        
+
         public Material gizmoMaterial
         {
             get { return m_GizmoMaterial; }
@@ -33,12 +41,6 @@ namespace Unity.Labs.SuperScience
         {
             get { return m_GizmoCutoffMaterial; }
         }
-
-        [SerializeField]
-        Material m_GizmoMaterial;
-
-        [SerializeField]
-        Material m_GizmoCutoffMaterial;
 
         void Awake()
         {

--- a/GizmoModule/Sample/SampleGizmos.cs
+++ b/GizmoModule/Sample/SampleGizmos.cs
@@ -5,8 +5,10 @@ using UnityEngine.XR;
 
 public class SampleGizmos : MonoBehaviour
 {
+#pragma warning disable 649
     [SerializeField]
     Transform m_OtherHand;
+#pragma warning restore 649
 
     void Start()
     {

--- a/PhysicsTracker/ExampleScripts/DrawPhysicsData.cs
+++ b/PhysicsTracker/ExampleScripts/DrawPhysicsData.cs
@@ -26,7 +26,7 @@ namespace Unity.Labs.SuperScience.Example
         static readonly Color k_AngularVelocityColor = Color.white;
         static readonly Color k_DirectIntegrationColor = Color.red;
 
-
+#pragma warning disable 649
         [SerializeField]
         [Tooltip("The object to track in space and report physics data on.")]
         Transform m_ToTrack;
@@ -50,21 +50,22 @@ namespace Unity.Labs.SuperScience.Example
         [SerializeField]
         [Tooltip("Should we use the PhysicsTracker's reported direction for physics data, or just report magnitudes?")]
         bool m_UseDirection = true;
+#pragma warning restore 649
 
         // We have a physicsTracker for getting the smooth data, and hold the last position for doing direct integration
         PhysicsTracker m_MotionData = new PhysicsTracker();
         Vector3 m_LastPosition;
 
-	    void Start ()
+        void Start ()
         {
             m_MotionData.Reset(m_ToTrack.position, m_ToTrack.rotation, Vector3.zero, Vector3.zero);
             m_LastPosition = m_ToTrack.position;
-	    }
-	
-	    /// <summary>
+        }
+
+        /// <summary>
         /// Sends updated data to the physicsTracker, and then draws the calculated data
         /// </summary>
-	    void Update ()
+        void Update ()
         {
             m_MotionData.Update(m_ToTrack.position, m_ToTrack.rotation, Time.smoothDeltaTime);
             if (m_DrawSmoothSpeed)
@@ -131,6 +132,6 @@ namespace Unity.Labs.SuperScience.Example
             // Store the last position so we can integrate it again next frame
             m_LastPosition = m_ToTrack.position;
 
-	    }
+        }
     }
 }

--- a/Stabilizr/Stabilizr.cs
+++ b/Stabilizr/Stabilizr.cs
@@ -15,6 +15,7 @@ namespace Unity.Labs.SuperScience
         const float k_AngleStabilization = 4.0f;
         const float k_90FPS = 1.0f/90.0f;
 
+#pragma warning disable 649
         [SerializeField]
         [Tooltip("The transform to match position and orientation - ie. a tracke controller")]
         Transform m_FollowSource;
@@ -30,6 +31,7 @@ namespace Unity.Labs.SuperScience
         [SerializeField]
         [Tooltip("When enabled, the object's endpoint will be considered for stabilization")]
         bool m_UseEndPoint = true;
+#pragma warning restore 649
 
         void LateUpdate ()
         {


### PR DESCRIPTION
### Purpose of this PR

Deal with warnings in 2018.3 and .Net 4.x runtime

### Testing status

Warnings are gone

### Technical risk

None

### Comments to reviewers

Had SuperScience in my project when reviewing our 2018.3 update so I figured I'd deal w/ this :)