### PR TITLE
Suppress warnings on serialized fields

### DIFF
--- a/EditorDelegates/EditorDelegatesUser.cs
+++ b/EditorDelegates/EditorDelegatesUser.cs
@@ -9,11 +9,13 @@ namespace Unity.Labs.SuperScience
     /// </summary>
     public class EditorDelegatesUser : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         Text m_MouseOverText;
 
         [SerializeField]
         Text m_FocusedText;
+#pragma warning restore 649
 
         void Awake()
         {

--- a/GizmoModule/GizmoModule.cs
+++ b/GizmoModule/GizmoModule.cs
@@ -9,6 +9,7 @@ namespace Unity.Labs.SuperScience
         public const float RayLength = 100f;
         const float k_RayWidth = 0.001f;
 
+#pragma warning disable 649
         [SerializeField]
         [Tooltip("Default sphere mesh used for drawing gizmo spheres.")]
         Mesh m_SphereMesh;
@@ -21,8 +22,15 @@ namespace Unity.Labs.SuperScience
         [Tooltip("Default quad mesh used for drawing gizmo wedges.")]
         Mesh m_QuadMesh;
 
+        [SerializeField]
+        Material m_GizmoMaterial;
+
+        [SerializeField]
+        Material m_GizmoCutoffMaterial;
+#pragma warning restore 649
+
         MaterialPropertyBlock m_GizmoProperties;
-        
+
         public Material gizmoMaterial
         {
             get { return m_GizmoMaterial; }
@@ -32,12 +40,6 @@ namespace Unity.Labs.SuperScience
         {
             get { return m_GizmoCutoffMaterial; }
         }
-
-        [SerializeField]
-        Material m_GizmoMaterial;
-
-        [SerializeField]
-        Material m_GizmoCutoffMaterial;
 
         void Awake()
         {

--- a/GizmoModule/Sample/SampleGizmos.cs
+++ b/GizmoModule/Sample/SampleGizmos.cs
@@ -6,7 +6,10 @@ namespace Unity.Labs.SuperScience
 {
     public class SampleGizmos : MonoBehaviour
     {
-        [SerializeField] Transform m_OtherHand;
+#pragma warning disable 649
+        [SerializeField]
+        Transform m_OtherHand;
+#pragma warning restore 649
 
         void Start()
         {

--- a/ModificationResponse/ColorContributor.cs
+++ b/ModificationResponse/ColorContributor.cs
@@ -9,8 +9,10 @@ namespace Unity.Labs.SuperScience
     /// </summary>
     public class ColorContributor : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         Color m_Color;
+#pragma warning restore 649
 
         public Color color { get { return m_Color; } }
     }

--- a/PhysicsTracker/ExampleScripts/DrawPhysicsData.cs
+++ b/PhysicsTracker/ExampleScripts/DrawPhysicsData.cs
@@ -26,7 +26,7 @@ namespace Unity.Labs.SuperScience.Example
         static readonly Color k_AngularVelocityColor = Color.white;
         static readonly Color k_DirectIntegrationColor = Color.red;
 
-
+#pragma warning disable 649
         [SerializeField]
         [Tooltip("The object to track in space and report physics data on.")]
         Transform m_ToTrack;
@@ -50,21 +50,22 @@ namespace Unity.Labs.SuperScience.Example
         [SerializeField]
         [Tooltip("Should we use the PhysicsTracker's reported direction for physics data, or just report magnitudes?")]
         bool m_UseDirection = true;
+#pragma warning restore 649
 
         // We have a physicsTracker for getting the smooth data, and hold the last position for doing direct integration
         PhysicsTracker m_MotionData = new PhysicsTracker();
         Vector3 m_LastPosition;
 
-	    void Start ()
+        void Start ()
         {
             m_MotionData.Reset(m_ToTrack.position, m_ToTrack.rotation, Vector3.zero, Vector3.zero);
             m_LastPosition = m_ToTrack.position;
-	    }
-	
-	    /// <summary>
+        }
+
+        /// <summary>
         /// Sends updated data to the physicsTracker, and then draws the calculated data
         /// </summary>
-	    void Update ()
+        void Update ()
         {
             m_MotionData.Update(m_ToTrack.position, m_ToTrack.rotation, Time.smoothDeltaTime);
             if (m_DrawSmoothSpeed)
@@ -131,6 +132,6 @@ namespace Unity.Labs.SuperScience.Example
             // Store the last position so we can integrate it again next frame
             m_LastPosition = m_ToTrack.position;
 
-	    }
+        }
     }
 }

--- a/Stabilizr/Stabilizr.cs
+++ b/Stabilizr/Stabilizr.cs
@@ -15,6 +15,7 @@ namespace Unity.Labs.SuperScience
         const float k_AngleStabilization = 4.0f;
         const float k_90FPS = 1.0f/90.0f;
 
+#pragma warning disable 649
         [SerializeField]
         [Tooltip("The transform to match position and orientation - ie. a tracke controller")]
         Transform m_FollowSource;
@@ -30,6 +31,7 @@ namespace Unity.Labs.SuperScience
         [SerializeField]
         [Tooltip("When enabled, the object's endpoint will be considered for stabilization")]
         bool m_UseEndPoint = true;
+#pragma warning restore 649
 
         void LateUpdate ()
         {


### PR DESCRIPTION
### Purpose of this PR

Deal with warnings in 2018.3 and .Net 4.x runtime

### Testing status

Warnings are gone

### Technical risk

None

### Comments to reviewers

Had SuperScience in my project when reviewing our 2018.3 update so I figured I'd deal w/ this :)