### PR TITLE
Fix compile errors in 2019

### DIFF
--- a/Runtime/GizmoModule/Sample/SampleGizmos.cs
+++ b/Runtime/GizmoModule/Sample/SampleGizmos.cs
@@ -1,6 +1,4 @@
 ﻿using UnityEngine;
-using UnityEngine.SpatialTracking;
-using UnityEngine.XR;
 
 namespace Unity.Labs.SuperScience
 {
@@ -10,15 +8,6 @@ namespace Unity.Labs.SuperScience
         [SerializeField]
         Transform m_OtherHand;
 #pragma warning restore 649
-
-        void Start()
-        {
-            if (XRDevice.isPresent)
-            {
-                GetComponent<TrackedPoseDriver>().enabled = true;
-                m_OtherHand.GetComponent<TrackedPoseDriver>().enabled = true;
-            }
-        }
 
         void Update()
         {


### PR DESCRIPTION
### Purpose of this PR

Remove references to UnityEngine.SpatialTracking and TrackedPoseDriver to fix compile errors in Unity 2019

### Testing status

Works in 2019

### Technical risk

None -- only deletes code

### Comments to reviewers

It's too bad we lose the XR-ness of this example, but it's not necessary to show off the gizmo module. If this becomes a packman package we can maybe bring this back and add a dependency on legacy input helpers.
