### PR TITLE
Clear asset list as well in MissingProjectReferences. 

### DIFF
--- a/Missingreferences/Editor/MissingProjectReferences.cs
+++ b/Missingreferences/Editor/MissingProjectReferences.cs
@@ -40,6 +40,7 @@ namespace Unity.Labs.SuperScience
         {
             m_Scanned = true;
             m_Prefabs.Clear();
+            m_Assets.Clear();
             foreach (var path in AssetDatabase.GetAllAssetPaths())
             {
                 if (Path.IsPathRooted(path))


### PR DESCRIPTION
### Purpose of this PR

Fixes duplicate entries on pressing Refresh multiple times in MissingProjectReferences window.
![20190911-233205](https://user-images.githubusercontent.com/2693840/64737233-a5c48180-d4ec-11e9-9151-a390e2728d9a.gif)

### Testing status

Doesn't duplicate entries anymore.
![20190911-233220](https://user-images.githubusercontent.com/2693840/64737239-a826db80-d4ec-11e9-914d-0db80246aaa2.gif)

### Technical risk

low.