### PR TITLE
Add project and hierarchy Item GUI

### DIFF
--- a/Editor/MissingReferences/MissingReferencesWindow.cs
+++ b/Editor/MissingReferences/MissingReferencesWindow.cs
@@ -166,7 +166,7 @@ namespace Unity.Labs.SuperScience
             public override void Draw()
             {
                 var wasVisible = m_Visible;
-                var label = string.Format(k_LabelFormat, m_GameObject.name, Count);
+                var label = string.Format(k_LabelFormat, m_GameObject ? m_GameObject.name : "Scene Root", Count);
                 if (m_IsMissingPrefab)
                     label = string.Format(k_MissingPrefabLabelFormat, label);
 

--- a/Editor/MissingReferences/MissingReferencesWindow.cs
+++ b/Editor/MissingReferences/MissingReferencesWindow.cs
@@ -34,7 +34,7 @@ namespace Unity.Labs.SuperScience
             /// Container for component scan results. Just as with GameObjectContainer, we initialize one of these
             /// using a component to scan it for missing references and retain the results
             /// </summary>
-            class ComponentContainer
+            internal class ComponentContainer
             {
                 const string k_MissingScriptLabel = "<color=red>Missing Script!</color>";
 
@@ -84,10 +84,15 @@ namespace Unity.Labs.SuperScience
             readonly GameObject m_GameObject;
             readonly List<GameObjectContainer> m_Children = new List<GameObjectContainer>();
             readonly List<ComponentContainer> m_Components = new List<ComponentContainer>();
+            internal List<GameObjectContainer> Children => m_Children;
+            internal List<ComponentContainer> Components => m_Components;
+            
             bool m_IsMissingPrefab;
             int m_MissingReferencesInChildren;
             int m_MissingReferencesInComponents;
 
+            internal bool HasMissingReferences => m_IsMissingPrefab || m_MissingReferencesInComponents > 0;
+            
             bool m_Visible;
             bool m_ShowComponents;
             bool m_ShowChildren;
@@ -321,6 +326,16 @@ namespace Unity.Labs.SuperScience
             m_Options.IncludeUnsetMethods = EditorGUILayout.Toggle(Styles.IncludeUnsetMethodsContent, m_Options.IncludeUnsetMethods);
             if (GUILayout.Button(k_ScanButtonName))
                 Scan(m_Options);
+        }
+
+        protected virtual void DrawItem(Rect selectionRect)
+        {
+            selectionRect.xMin = selectionRect.xMax - 2;
+            selectionRect.x -= 4;
+            var c = GUI.color;
+            GUI.color = Color.red;
+            GUI.DrawTexture(selectionRect, Texture2D.whiteTexture);
+            GUI.color = c;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

Adds in-scene and in-project highlighting of items that have missing references. Helps to quickly identify those.
In addition to showing the highlight, items are pinged after the scan so all issues are shown immediately.

![image](https://user-images.githubusercontent.com/2693840/105099175-8740a400-5aab-11eb-90af-8fb60ab67592.png)

![image](https://user-images.githubusercontent.com/2693840/105099243-a63f3600-5aab-11eb-8a2a-aef5b5ba3383.png)

### Testing status

Manually tested against 2019.1-2021.1

### Comments to reviewers

There are some additional improvements that could be done on top (e.g. showing which fields are missing similar to how Prefab Override state is shown), but this felt like a good start to PR.

Also @mtschoen the first commit here is a null ref fix for the scene reference finder, since the first GameObject is always null (the scene root doesn't have a GameObject).