### PR TITLE
Fix Namespace upgrades for 2021.2

### DIFF
--- a/Editor/MissingReferences/MissingSceneReferences.cs
+++ b/Editor/MissingReferences/MissingSceneReferences.cs
@@ -2,6 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
+#if UNITY_2021_2_OR_NEWER
+using UnityEditor.SceneManagement;
+#else
+using UnityEditor.Experimental.SceneManagement;
+#endif
 
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -41,7 +46,7 @@ namespace Unity.Labs.SuperScience
             m_SceneRoots.Clear();
 
             // If we are in prefab isolation mode, scan the prefab stage instead of the active scene
-            var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
             if (prefabStage != null)
             {
                 ScanScene(prefabStage.scene, options);

--- a/Editor/MissingReferences/MissingSceneReferences.cs
+++ b/Editor/MissingReferences/MissingSceneReferences.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
-using UnityEditor.Experimental.SceneManagement;
+
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -41,7 +41,7 @@ namespace Unity.Labs.SuperScience
             m_SceneRoots.Clear();
 
             // If we are in prefab isolation mode, scan the prefab stage instead of the active scene
-            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
             if (prefabStage != null)
             {
                 ScanScene(prefabStage.scene, options);


### PR DESCRIPTION
### Purpose of this PR

Quick define to handle 2021.1 & 2021.2 in the same code base.
Experimental scene management namespaces got made official.

### Testing status

Tested using 2021.1 and 2021.2

### Technical risk

This could cause some issues in very early 2021.2 alpha versions that are technically 2021.2 but don't include the namespace change. Should not affect things otherwise.

### Comments to reviewers

