### PR TITLE
Make GizmoModule optionally an IModule

### DIFF
--- a/Runtime/GizmoModule/GizmoModule.cs
+++ b/Runtime/GizmoModule/GizmoModule.cs
@@ -1,8 +1,15 @@
-﻿using UnityEngine;
+﻿#if INCLUDE_MODULE_LOADER
+using Unity.XRTools.ModuleLoader;
+#endif
+
+using UnityEngine;
 
 namespace Unity.Labs.SuperScience
 {
     public class GizmoModule : MonoBehaviour
+#if INCLUDE_MODULE_LOADER
+    , IModule
+#endif
     {
         public static GizmoModule instance;
 
@@ -117,5 +124,14 @@ namespace Unity.Labs.SuperScience
             var wedgeMatrix = Matrix4x4.TRS(position, rotation, Vector3.one * radius);
             Graphics.DrawMesh(m_QuadMesh, wedgeMatrix, m_GizmoCutoffMaterial, 0, null, 0, m_GizmoProperties);
         }
+
+#if INCLUDE_MODULE_LOADER
+        void IModule.LoadModule()
+        {
+            instance = this;
+        }
+
+        void IModule.UnloadModule() { }
+#endif
     }
 }

--- a/Runtime/Unity.Labs.SuperScience.asmdef
+++ b/Runtime/Unity.Labs.SuperScience.asmdef
@@ -1,3 +1,21 @@
-﻿{
-	"name": "Unity.Labs.SuperScience"
+{
+    "name": "Unity.Labs.SuperScience",
+    "references": [
+        "Unity.XRTools.ModuleLoader.Interfaces"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.xrtools.module-loader",
+            "expression": "1.0.0",
+            "define": "INCLUDE_MODULE_LOADER"
+        }
+    ]
 }


### PR DESCRIPTION
### Purpose of this PR

This makes it easier to reference GizmoModule. Previously, you had to have it set up in the scene. Now, for projects that use Module Loader you can use `GetModule

### Testing status

I've been using this while working on EditorXR

### Technical risk

Low. Code only compiles in if Module Loader package is present

### Comments to reviewers

I've had this kicking around for a while and forgot to open a PR! :)
