### PR TITLE
Add delete functionality to HiddenHierarchy

### DIFF
--- a/Editor/HiddenHierarchy.cs
+++ b/Editor/HiddenHierarchy.cs
@@ -181,6 +181,13 @@ namespace Unity.Labs.SuperScience
 
         void OnGUI()
         {
+            if (Event.current.type == EventType.KeyUp && Event.current.keyCode == KeyCode.Delete)
+            {
+                var activeObject = Selection.activeGameObject;
+                if (activeObject != null)
+                    DestroyImmediate(activeObject);
+            }
+
             using (new GUILayout.HorizontalScope())
             {
                 m_AutoUpdate = EditorGUILayout.Toggle(k_AutoUpdateFieldLabel, m_AutoUpdate);


### PR DESCRIPTION
### Purpose of this PR

Adds a delete button and hotkey to HiddenHierarchy, so you can delete/destroy hidden stuff.

### Testing status

Tested while working on EditorXR, MARS, and other projects

### Technical risk

Low -- destroying this stuff might be problematic but by definition this tool is enabling power users to do things the normal UI won't let you do.

### Comments to reviewers

Again, this one was kicking around for a while and I never got it into PR
